### PR TITLE
fix: bump 'engines' property in package.json to allow Node.js 20

### DIFF
--- a/examples/next/package.json
+++ b/examples/next/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "engines": {
-    "node": ">=16 <=18",
+    "node": ">=16 <=20",
     "pnpm": "8"
   },
   "dependencies": {

--- a/examples/vanilla/package.json
+++ b/examples/vanilla/package.json
@@ -9,7 +9,7 @@
     "start": "vite preview"
   },
   "engines": {
-    "node": ">=16 <=18",
+    "node": ">=16 <=20",
     "pnpm": "8"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "url": "https://github.com/azero-id/resolver/issues"
   },
   "engines": {
-    "node": ">=16 <=18",
+    "node": ">=16 <=20",
     "pnpm": "8"
   },
   "workspaces": [

--- a/packages/resolver-core/package.json
+++ b/packages/resolver-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azns/resolver-core",
   "author": "AZERO.ID <hello@azero.id> (https://azero.id)",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Vanilla JS/TS Library for resolving Domains issued by AZERO.ID",
   "homepage": "https://azero.id",
   "type": "module",
@@ -25,7 +25,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=16 <=18",
+    "node": ">=16 <=20",
     "pnpm": "8"
   },
   "scripts": {

--- a/packages/resolver-react/package.json
+++ b/packages/resolver-react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@azns/resolver-react",
   "author": "AZERO.ID <hello@azero.id> (https://azero.id)",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "React Hooks Library for resolving Domains issued by AZERO.ID",
   "homepage": "https://azero.id",
   "type": "module",
@@ -25,7 +25,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=16 <=18",
+    "node": ">=16 <=20",
     "pnpm": "8"
   },
   "scripts": {


### PR DESCRIPTION
It doesn't show up for those using `pnpm` as a package manager, but for downstream projects using `npm` and Node.js > 18, we get the following warning (or error, depending on your npm config):
```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@azns/resolver-core@1.6.0',
npm WARN EBADENGINE   required: { node: '>=16 <=18', pnpm: '8' },
npm WARN EBADENGINE   current: { node: 'v20.12.2', npm: '10.5.2' }
npm WARN EBADENGINE }
```

Node.js 20.12.2 is the current LTS version, and should be supported, unless there is specific reason not to do so.

This PR simply bumps the restriction to include Node 20.